### PR TITLE
Fixes port number option; clears up the ambiguity for the engine

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ class Influxdb {
     if (port && !(port >= 1 && port <= 65535)) {
       throw Error('`port` should between 1 and 65535');
     }
-    this._port = port || this._protocol === 'https' ? 443 : 80;
+    this._port = port || (this._protocol === 'https' ? 443 : 80);
 
     if (!token) {
       throw Error('`token` is required');


### PR DESCRIPTION
Fix for allowing port numbers to be provided. Previously the old syntax was ambiguous, and JS interprets it as:
```
(port || this._protocol === 'https') ? 443 : 80
```

as opposed to:
```
port || (this._protocol === 'https' ? 443 : 80)
```

As it binds the or operator tighter than the ternary syntax.