### PR TITLE
fixed escape order

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ class Influxdb {
           .join('');
 
         const fieldsString = Object.keys(fields)
-          .map(fieldKey => `${escape(fieldKey, [ ',', '=', ' ' ])}=${typeof(fields[fieldKey]) === 'string' ? `"${escape(fields[fieldKey], [ '"', '\\' ])}"` : fields[fieldKey]}`)
+          .map(fieldKey => `${escape(fieldKey, [ ',', '=', ' ' ])}=${typeof(fields[fieldKey]) === 'string' ? `"${escape(fields[fieldKey], [ '\\', '"' ])}"` : fields[fieldKey]}`)
           .join(',');
 
         timestamp = timestamp ? ' ' + timestamp : '';


### PR DESCRIPTION
Fixed the escape order of field strings.

First " was escaped to \\" in a second step \\" was escaped to \\\\" which leads to and parsing error in influxdb.
So I just switched the escape order to first escape all \ and afterwards escaping ". 
Which leads to the right escape sequence \\".

This can be validated by following code:
`
await influxdb.write(
    {
      org,
      bucket,
    },
    [
      {
        measurement: "test2",
        fields: {
          teststring: '"',
        },
      },
    ]
  )
`

